### PR TITLE
fix to not scroll the page when space key is hit

### DIFF
--- a/a11yclick.js
+++ b/a11yclick.js
@@ -13,6 +13,9 @@ var a11yclick = function(event) {
     if (type === 'click') {
         return true;
     } else if (type === 'keydown') {
+        if(code === 32){
+        	event.preventDefault();
+        }
         if (code === 32 || code === 13) {
             return true;
         }


### PR DESCRIPTION
By adding this extra preventDefault() the page will no longer scroll down when the user hits the space bar on the new custom control just like on a native button
